### PR TITLE
[fix] fix the search result shouldn't be updated after searching a new keyword

### DIFF
--- a/feature/search/src/main/java/taiwan/no/one/feat/search/presentation/fragments/IndexFragment.kt
+++ b/feature/search/src/main/java/taiwan/no/one/feat/search/presentation/fragments/IndexFragment.kt
@@ -39,6 +39,7 @@ import com.devrapid.kotlinknifer.invisible
 import com.devrapid.kotlinknifer.loge
 import com.devrapid.kotlinknifer.visible
 import com.google.android.material.transition.MaterialSharedAxis
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.debounce
@@ -153,6 +154,7 @@ internal class IndexFragment : BaseFragment<BaseActivity<*>, FragmentSearchIndex
         }
     }
 
+    @OptIn(FlowPreview::class)
     @SuppressLint("ClickableViewAccessibility")
     override fun componentListenersBinding() {
         binding.root.setOnTouchListener { v, event ->

--- a/feature/search/src/main/java/taiwan/no/one/feat/search/presentation/viewmodels/ResultViewModel.kt
+++ b/feature/search/src/main/java/taiwan/no/one/feat/search/presentation/viewmodels/ResultViewModel.kt
@@ -62,8 +62,14 @@ internal class ResultViewModel(
         if (curKeyword.isBlank()) return@launch
         _musics.value = runCatching {
             val newResult = fetchMusicCase.execute(FetchMusicReq(curKeyword, curPage))
-            // Add the new result top on the old list.
-            _musics.value?.getOrNull()?.toMutableList()?.apply { addAll(newResult) } ?: newResult
+            // Research a new keyword, it shouldn't append onto the old list.
+            if (page == 0) {
+                newResult
+            }
+            else {
+                // Add the new result top on the old list.
+                _musics.value?.getOrNull()?.toMutableList()?.apply { addAll(newResult) } ?: newResult
+            }
         }
     }
 


### PR DESCRIPTION
The issue is from #10

## How to fix

1. added the reset condition to the viewmodel when a user puts a new keyword to search
2. bascially, `page == 0` will be that searching a new keyword
3. we won't append the result into the old result list